### PR TITLE
libpng12-dev do not Exist, update mantis 2.11.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,14 +5,14 @@ RUN a2enmod rewrite
 
 RUN set -xe \
     && apt-get update \
-    && apt-get install -y libpng12-dev libjpeg-dev libpq-dev libxml2-dev libldap2-dev \
+    && apt-get install -y libpng-dev libjpeg-dev libpq-dev libxml2-dev libldap2-dev \
     && docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
     && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
     && docker-php-ext-install gd mbstring pdo_mysql mysqli soap ldap \
     && rm -rf /var/lib/apt/lists/*
 
-ENV MANTIS_VER 2.6.0
-ENV MANTIS_MD5 e2704916382459f751abcf3dc4872e44
+ENV MANTIS_VER 2.11.1
+ENV MANTIS_MD5 89c6f0d1a68968e43f8a45bd98b1ea00
 ENV MANTIS_URL http://jaist.dl.sourceforge.net/project/mantisbt/mantis-stable/${MANTIS_VER}/mantisbt-${MANTIS_VER}.tar.gz
 ENV MANTIS_FILE mantisbt.tar.gz
 


### PR DESCRIPTION
libpng12-dev do not exist anymore, Image cretion will fail, new library is called libpng-dev
Updated mantis to Version 2.11.1